### PR TITLE
Make correct navigation item be selected in header

### DIFF
--- a/cpnav/CpNavPlugin.php
+++ b/cpnav/CpNavPlugin.php
@@ -89,6 +89,17 @@ class CpNavPlugin extends BasePlugin
                             // We're on a page that's disabled - redirect to the first enabled one!
                             craft()->request->redirect(UrlHelper::getUrl($enabledNavs[0]->url));
                         }
+                    } else if (craft()->request->path ==
+                        preg_replace(
+                            sprintf('/^(https?:\/\/)?(%s)?\/?%s\//', preg_quote(craft()->getSiteUrl(''), '/'), preg_quote(craft()->config->get('cpTrigger')), '/'),
+                            '',
+                            $nav->url
+                        ) && $nav-> enabled && $nav->manualNav) {
+
+                        // Add some JavaScript to correct the selected nav item for manually added navigation items.
+                        // Have to do this with JavaScript for now as the nav item selection is made after the modifyCpNav hook.
+                        $js = '$(function() { $("#nav a").removeClass("sel"); $("#nav li#nav-' . $nav->handle . ' a").addClass("sel"); });';
+                        craft()->templates->includeJs($js);
                     }
                 }
             }


### PR DESCRIPTION
I've added some JavaScript and a small conditional to correct which navigation item is selected for manually added navigation items. This significantly improves the look and usability for manually added navigation items, and is especially useful if adding nav items for individual entries (a homepage, for example).

Before:
![homepage_-_young___wilmoth_old](https://cloud.githubusercontent.com/assets/163976/6884099/a7fef21a-d5a9-11e4-95d9-2cc2fa017651.png)

After:
![homepage_-_young___wilmoth](https://cloud.githubusercontent.com/assets/163976/6884102/ffd8a97c-d5a9-11e4-98ea-27ab19e48da1.png)

The preg_replace is necessary to be able to correctly handle both absolute and relative URLs as inputted by the user.

Unfortunately this does have to be done with JavaScript injection right now as the point at which nav items are decided if they are "selected" or not happens after the modifyCpNav hook that is available to plugins.