### PR TITLE
SVG Path Issue

### DIFF
--- a/cpnav/services/CpNavService.php
+++ b/cpnav/services/CpNavService.php
@@ -80,7 +80,9 @@ class CpNavService extends BaseApplicationComponent
                             $asset = craft()->assets->getFileById($newNav->customIcon);
 
                             if ($asset) {
-                                $path = $asset->getSource()->settings['path'] . $asset->getFolder()->path . $asset->filename;
+
+                                $asset_path = craft()->assetSources->populateSourceType($asset->getSource());
+                                $path = $asset_path->getLocalCopy($asset);
 
                                 if (IOHelper::fileExists($path)) {
                                     $iconSvg = IOHelper::getFileContents($path);


### PR DESCRIPTION
When using environment variables such as `{baseUrl}` or `{basePath}` in Asset path settings, the SVG does not render.