### PR TITLE
Fix icon path check to ignore directories

### DIFF
--- a/src/models/Navigation.php
+++ b/src/models/Navigation.php
@@ -127,7 +127,7 @@ class Navigation extends Model
             // Craft changed the handling of svg icons. Formerly it returned the svg content. Now it returns just
             // the icon path and handles the rendering in twig. We have to manually get the icon content to display
             // it in our javascript
-            if (@file_exists($this->icon)) {
+            if (@is_file($this->icon)) {
                 $this->pluginIcon = @file_get_contents($this->icon);
             } else {
                 $this->craftIcon = $this->icon;


### PR DESCRIPTION
Installing the plugin caused the icon for the "Assets" entry in the sidebar to revert to the fallback letter-in-a-circle display.

Had a bit of a flick through the code, turns out my general structure of including an "assets" folder in the root "web" folder was causing the `file_exists` check to return true.

Switching it to `is_file` should be a fine substitute that doesn't risk hitting directories as well.