### PR TITLE
Fix for count() error in PHP 7.2+

### DIFF
--- a/src/services/CpNavService.php
+++ b/src/services/CpNavService.php
@@ -128,7 +128,7 @@ class CpNavService extends Component
             if (!CpNav::$plugin->navigationService->getByHandle($layoutId, $key)) {
 
                 // Handleball off to the main menu regeneration function - no need to duplicate code
-                $this->regenerateNav($layoutId, null, $defaultNavs->nav());
+                $this->regenerateNav($layoutId, [], $defaultNavs->nav());
             }
         }
     }


### PR DESCRIPTION
In PHP 7.2+, null can no longer be passed to count(); its argument must implement the Countable interface. The simplest fix is passing a blank array instead of null. count([]) returns the same int 0 that count(null) used to, so no other changes are needed.