### PR TITLE
Allow CpNav plugin services to be used in console requests

### DIFF
--- a/src/services/Service.php
+++ b/src/services/Service.php
@@ -186,10 +186,15 @@ class Service extends Component
 
     private function _getOriginalNav()
     {
-        // Just call it - we don't want the result of this function, we just want the hook called,
-        // which in turn calls our function above. Our hook will store the original nav in a private 
-        // variable, for final use here. Might be a better way?
-        (new Cp())->nav();
+        // Allow CpNav services to be called by console requests
+        // https://github.com/verbb/cp-nav/issues/85
+        if(!Craft::$app->getRequest()->getIsConsoleRequest()) {
+
+            // Just call it - we don't want the result of this function, we just want the hook called,
+            // which in turn calls our function above. Our hook will store the original nav in a private
+            // variable, for final use here. Might be a better way?
+            (new Cp())->nav();
+        }
 
         return $this->_originalNavItems;
     }


### PR DESCRIPTION
Relates to #85.

This prevents the CP nav call from being attempted under console requests, allowing CP Nav plugin services to be called without errors, due to the assumption they are web requests.