### PR TITLE
Update Permission Map to allow settings key for Craft versions at least 5.6.0

### DIFF
--- a/src/helpers/Permissions.php
+++ b/src/helpers/Permissions.php
@@ -189,7 +189,7 @@ class Permissions
             'utilities' => (bool)Craft::$app->getUtilities()->getAuthorizedUtilityTypes(),
 
             'graphql' => $isAdmin && $generalConfig->enableGql,
-            'settings' => $isAdmin && $generalConfig->allowAdminChanges,
+            'settings' => $isAdmin && (version_compare(Craft::$app->getVersion(), '5.6.0', '>=') || $generalConfig->allowAdminChanges),
             'plugin-store' => $isAdmin,
         ];
 


### PR DESCRIPTION
Since Craft 5.6.0, the settings route is available in a read-only mode, even when the `allowAdminChanges` config is `false`.

See https://github.com/craftcms/cms/pull/16265